### PR TITLE
Use "semantic linebreaks"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://secure.travis-ci.org/lloyd/node-toobusy.png)](http://travis-ci.org/lloyd/node-toobusy)
 
-What happens when your service is overwhelmed with traffic?  Your
-server can do one of two things:
+What happens when your service is overwhelmed with traffic?
+Your server can do one of two things:
 
   * Stop working, or...
   * Keep serving as many requests as possible
@@ -12,10 +12,14 @@ This library helps you do the latter.
 
 ## How it works
 
-`toobusy` polls the node.js event loop and keeps track of "lag", which is long requests wait in node's event queue to be processed.
+`toobusy` polls the node.js event loop and keeps track of "lag",
+which is long requests wait in node's event queue to be processed.
 When lag crosses a threshold, `toobusy` tells you that you're *too busy*.
-At this point you can stop request processing early (before you spend too much time on them and compound the problem), and return a "Server Too Busy" response.
-This allows your server to stay *responsive* under extreme load, and continue serving as many requests as possible.
+At this point you can stop request processing early
+(before you spend too much time on them and compound the problem),
+and return a "Server Too Busy" response.
+This allows your server to stay *responsive* under extreme load,
+and continue serving as many requests as possible.
 
 ## installation
 
@@ -54,16 +58,24 @@ This allows your server to stay *responsive* under extreme load, and continue se
 
 ## tunable parameters
 
-The one knob that the library exposes is "maximum lag".  This number represents the maximum amount of time in milliseconds that the event queue is behind, before we consider the process *too busy*.
+The one knob that the library exposes is "maximum lag".
+This number represents the maximum amount of time in milliseconds that the event queue is behind,
+before we consider the process *too busy*.
 
     // set maximum lag to an aggressive value
     require('toobusy').maxLag(10);
 
-The default value is 70ms which allows an "average" server to run at 90-100% cpu and keeps request latency at around 200ms.
-For comparison, a value of 10ms results in 60-70% CPU usage while latency for "average" requests stays at about 40ms.
+The default value is 70ms,
+which allows an "average" server to run at 90-100% CPU
+and keeps request latency at around 200ms.
+For comparison, a value of 10ms results in 60-70% CPU usage,
+while latency for "average" requests stays at about 40ms.
 
-These numbers are only examples, and the specifics of your hardware and application can change them drastically, so experiment!  The default of 70 should get you started.
+These numbers are only examples,
+and the specifics of your hardware and application can change them drastically,
+so experiment!
+The default of 70 should get you started.
 
 ## license
 
-http://wtfpl.org
+[WTFPL](http://wtfpl.org)


### PR DESCRIPTION
[Semantic linebreaks](http://rhodesmill.org/brandon/2012/one-sentence-per-line/) allow neater diffs, easier editing, and text-wrapping in natural places.
