### PR TITLE
Add new function to retrieve the lag 

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,3 +2,4 @@ var bindings = require('bindings')('toobusy.node')
 module.exports = bindings.toobusy;
 module.exports.shutdown = bindings.shutdown;
 module.exports.maxLag = bindings.maxLag;
+module.exports.lag = bindings.lag;

--- a/tests.js
+++ b/tests.js
@@ -40,4 +40,22 @@ describe('toobusy()', function() {
     }
     load();
   });
+
+  it('should return a lag value after a little load', function(done) {
+    function load() {
+      if (toobusy()) {
+        var lag = toobusy.lag();
+        should.exist(lag);
+        lag.should.be.above(1);
+        return done();
+      }
+      var start = new Date();
+      while ((new Date() - start) < 250) {
+        for (var i = 0; i < 1e5;) i++;
+      }
+      setTimeout(load, 0);
+    }
+    load();
+  });
 });
+

--- a/toobusy.cc
+++ b/toobusy.cc
@@ -39,6 +39,11 @@ Handle<Value> ShutDown(const Arguments& args) {
     return Undefined();
 }
 
+Handle<Value> Lag(const Arguments& args) {
+    HandleScope scope;
+    return scope.Close(Number::New(s_currentLag));
+}
+
 Handle<Value> HighWaterMark(const Arguments& args) {
     HandleScope scope;
 
@@ -87,6 +92,7 @@ extern "C" void init(Handle<Object> target) {
 
     target->Set(String::New("toobusy"), FunctionTemplate::New(TooBusy)->GetFunction());
     target->Set(String::New("shutdown"), FunctionTemplate::New(ShutDown)->GetFunction());
+    target->Set(String::New("lag"), FunctionTemplate::New(Lag)->GetFunction());
     target->Set(String::New("maxLag"), FunctionTemplate::New(HighWaterMark)->GetFunction());
     uv_timer_init(uv_default_loop(), &s_timer);
     uv_timer_start(&s_timer, every_second, POLL_PERIOD_MS, POLL_PERIOD_MS);


### PR DESCRIPTION
When determining what to set maxLag to, it's often helpful to know what the existing lag is on a production node process.
