### PR TITLE
Express.js example fails.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ and continue serving as many requests as possible.
     var toobusy = require('toobusy'),
         express = require('express');
     
-    var app = express.createServer();
+    var app = express();
     
     // middleware which blocks requests when we're too busy
     app.use(function(req, res, next) {
@@ -48,12 +48,13 @@ and continue serving as many requests as possible.
       res.send("I counted to " + i);
     });
     
-    app.listen(3000);
+    var server = app.listen(3000);
     
     process.on('SIGINT', function() {
-      app.close();
+      server.close();
       // calling .shutdown allows your process to exit normally
       toobusy.shutdown();
+      process.exit();
     });
 
 ## tunable parameters

--- a/examples/express.js
+++ b/examples/express.js
@@ -1,7 +1,7 @@
 var toobusy = require('..'),
     express = require('express');
 
-var app = express.createServer();
+var app = express();
 
 // Have grace under load
 app.use(function(req, res, next) {
@@ -19,9 +19,10 @@ app.get('/', function(req, res) {
   res.send("I counted to " + i);
 });
 
-app.listen(3000);
+var server = app.listen(3000);
 
 process.on('SIGINT', function() {
-  app.close();
+  server.close();
   toobusy.shutdown();
+  process.exit();
 });


### PR DESCRIPTION
The Express.js example probably works alright with Express 2, but not with 3. Also, added process.exit() to SIGINT handler, as the example simply does not exit otherwise. Fixed corresponding README.md content.
