### PR TITLE
[typo] - package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       "type": "WTFPL"
     }
   ],
-  "repositories": [
+  "repository": [
     {
       "type": "git",
       "url": "git://github.com/lloyd/node-toobusy.git"


### PR DESCRIPTION
because npm sayes:

```

npm WARN package.json toobusy@0.2.3 No repository field.
npm WARN package.json toobusy@0.2.3 'repositories' (plural) Not supported.
npm WARN package.json Please pick one as the 'repository' field
npm WARN package.json hiredis@0.1.15 No repository field.

```
