### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,26 +10,18 @@
     "should": "1.2.1",
     "mocha": "1.7.0"
   },
-  "maintainers": [
-    {
-      "name": "Lloyd Hilaiel",
-      "email": "lloyd@hilaiel.com"
-    }
-  ],
+  "author": {
+    "name": "Lloyd Hilaiel",
+    "email": "lloyd@hilaiel.com"
+  },
   "bugs": {
     "url": "https://github.com/lloyd/node-toobusy/issues"
   },
-  "licenses": [
-    {
-      "type": "WTFPL"
-    }
-  ],
-  "repositories": [
-    {
-      "type": "git",
-      "url": "git://github.com/lloyd/node-toobusy.git"
-    }
-  ],
+  "license": "WTFPL",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/lloyd/node-toobusy.git"
+  },
   "main": "./index.js",
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
Changing `repositories` to `repository` since it seems to be causing some warnings w/ deployer; https://deployer.personatest.org/55ff6e0.txt

Now passes http://package-json-validator.com/ with minimal warnings (missing recommended "keywords" and "contributors").
