### PR TITLE
node v0.11+ compatibility

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,6 +3,7 @@
     {
       'target_name': 'toobusy',
       'include_dirs': [
+        "<!(node -e \"require('nan')\")"
       ],
       'sources': [
         'toobusy.cc',

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "homepage": "https://github.com/lloyd/node-toobusy",
   "version": "0.2.4",
   "dependencies": {
-    "bindings": "1.1.0"
+    "bindings": "1.1.0",
+    "nan": "0.8.0"
   },
   "devDependencies": {
     "should": "1.2.1",

--- a/tests.js
+++ b/tests.js
@@ -33,7 +33,7 @@ describe('toobusy()', function() {
     function load() {
       if (toobusy()) return done();
       var start = new Date();
-      while ((new Date() - start) < 250) {
+      while ((new Date() - start) < 300) {
         for (var i = 0; i < 1e5;) i++;
       }
       setTimeout(load, 0);

--- a/toobusy.cc
+++ b/toobusy.cc
@@ -7,6 +7,7 @@
 #else
   #include <sys/time.h>
 #endif
+#include "nan.h"
 
 using namespace v8;
 
@@ -22,7 +23,8 @@ static uv_timer_t s_timer;
 static uint32_t s_currentLag;
 static uint64_t s_lastMark;
 
-Handle<Value> TooBusy(const Arguments& args) {
+NAN_METHOD(TooBusy) {
+    NanScope();
     // No HandleScope required, because this function allocates no
     // v8 classes that reside on the heap.
     bool block = false;
@@ -34,41 +36,37 @@ Handle<Value> TooBusy(const Arguments& args) {
         double r = (rand() / (double) RAND_MAX) * 100.0;
         if (r < pctToBlock) block = true;
     }
-    return block ? True() : False();
+    NanReturnValue(block ? True() : False());
 }
 
-Handle<Value> ShutDown(const Arguments& args) {
+NAN_METHOD(ShutDown) {
     // No HandleScope required, because this function allocates no
     // v8 classes that reside on the heap.
 
     uv_timer_stop(&s_timer);
-    return Undefined();
+    NanReturnUndefined();
 }
 
-Handle<Value> Lag(const Arguments& args) {
-    HandleScope scope;
-    return scope.Close(Integer::New(s_currentLag));
+NAN_METHOD(Lag) {
+    NanScope();
+    NanReturnValue(Integer::New(s_currentLag));
 }
 
-Handle<Value> HighWaterMark(const Arguments& args) {
-    HandleScope scope;
+NAN_METHOD(HighWaterMark) {
+    NanScope();
 
     if (args.Length() >= 1) {
         if (!args[0]->IsNumber()) {
-            return v8::ThrowException(
-                v8::Exception::Error(
-                    v8::String::New("expected numeric first argument")));
+            return NanThrowError("expected numeric first argument");
         }
         int hwm = args[0]->Int32Value();
         if (hwm < 10) {
-            return v8::ThrowException(
-                v8::Exception::Error(
-                    v8::String::New("maximum lag should be greater than 10ms")));
+            return NanThrowError("maximum lag should be greater than 10ms");
         }
         HIGH_WATER_MARK_MS = hwm;
     }
 
-    return scope.Close(Number::New(HIGH_WATER_MARK_MS));
+    NanReturnValue(Number::New(HIGH_WATER_MARK_MS));
 }
 
 static void every_second(uv_timer_t* handle, int status)
@@ -86,12 +84,11 @@ static void every_second(uv_timer_t* handle, int status)
 };
 
 extern "C" void init(Handle<Object> target) {
-    HandleScope scope;
 
-    target->Set(String::New("toobusy"), FunctionTemplate::New(TooBusy)->GetFunction());
-    target->Set(String::New("shutdown"), FunctionTemplate::New(ShutDown)->GetFunction());
-    target->Set(String::New("lag"), FunctionTemplate::New(Lag)->GetFunction());
-    target->Set(String::New("maxLag"), FunctionTemplate::New(HighWaterMark)->GetFunction());
+    target->Set(NanSymbol("toobusy"), FunctionTemplate::New(TooBusy)->GetFunction());
+    target->Set(NanSymbol("shutdown"), FunctionTemplate::New(ShutDown)->GetFunction());
+    target->Set(NanSymbol("lag"), FunctionTemplate::New(Lag)->GetFunction());
+    target->Set(NanSymbol("maxLag"), FunctionTemplate::New(HighWaterMark)->GetFunction());
     uv_timer_init(uv_default_loop(), &s_timer);
     uv_timer_start(&s_timer, every_second, POLL_PERIOD_MS, POLL_PERIOD_MS);
 };


### PR DESCRIPTION
The v8 api changed in v0.11 and `nan` makes compatibility across version much easier.

Tested with v0.8.26 v0.10.24 and v0.11.10

I had to bump the busy loop up to 300 for the load test to work across all versions.
