### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This library helps you do the latter.
 ## How it works
 
 `toobusy` polls the node.js event loop and keeps track of "lag",
-which is long requests wait in node's event queue to be processed.
+which is how long requests wait in node's event queue to be processed.
 When lag crosses a threshold, `toobusy` tells you that you're *too busy*.
 At this point you can stop request processing early
 (before you spend too much time on them and compound the problem),


### PR DESCRIPTION
Small typo in README

`toobusy` polls the node.js event loop and keeps track of "lag",
which is **how** long requests wait in node's event queue to be processed.

**how** was missing
