### PR TITLE
Update example to remove ms count - toobusy() returns boolean

### DIFF
--- a/examples/standalone.js
+++ b/examples/standalone.js
@@ -8,7 +8,7 @@ function worky() {
   var howBusy = toobusy();
   if (howBusy) {
     work /= 4;
-    console.log("I can't work! I'm too busy:", howBusy + "ms behind");
+    console.log("I can't work! I'm too busy");
   }
   work *= 2;
   for (var i = 0; i < work;) i++;


### PR DESCRIPTION
The toobusy() function is bound to a native plugin that returns true or false, not a ms count.
