### PR TITLE
Make dampening factor a tunable

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,3 +3,4 @@ module.exports = bindings.toobusy;
 module.exports.shutdown = bindings.shutdown;
 module.exports.maxLag = bindings.maxLag;
 module.exports.lag = bindings.lag;
+module.exports.dampeningFactor = bindings.dampeningFactor;

--- a/tests.js
+++ b/tests.js
@@ -2,10 +2,18 @@ const
 should = require('should'),
 toobusy = require('./');
 
+function tightWork() {
+  var start = new Date();
+  while ((new Date() - start) < 250) {
+    for (var i = 0; i < 1e5;) i++;
+  }
+}
+
 describe('the library', function() {
   it('should export a couple functions', function(done) {
     (toobusy).should.be.a('function');
     (toobusy.maxLag).should.be.a('function');
+    (toobusy.dampeningFactor).should.be.a('function');
     (toobusy.shutdown).should.be.a('function');
     done();
   });
@@ -32,10 +40,7 @@ describe('toobusy()', function() {
   it('should return true after a little load', function(done) {
     function load() {
       if (toobusy()) return done();
-      var start = new Date();
-      while ((new Date() - start) < 250) {
-        for (var i = 0; i < 1e5;) i++;
-      }
+      tightWork();
       setTimeout(load, 0);
     }
     load();
@@ -49,13 +54,85 @@ describe('toobusy()', function() {
         lag.should.be.above(1);
         return done();
       }
-      var start = new Date();
-      while ((new Date() - start) < 250) {
-        for (var i = 0; i < 1e5;) i++;
-      }
+      tightWork();
       setTimeout(load, 0);
     }
     load();
   });
 });
 
+describe('dampeningFactor', function() {
+  it('should default to 3', function(done) {
+    (toobusy.dampeningFactor()).should.equal(3);
+    done();
+  });
+  it('should throw an exception for values < 1', function(done) {
+    (function() { toobusy.dampeningFactor(0); }).should.throw;
+    done();
+  });
+  it('should be configurable', function(done) {
+    (toobusy.dampeningFactor(10)).should.equal(10);
+    (toobusy.dampeningFactor(5)).should.equal(5);
+    (toobusy.dampeningFactor()).should.equal(5);
+    done();
+  });
+});
+
+describe('dampeningFactor\'s behaviour', function() {
+  beforeEach(function resetToNotBusy(done) {
+    var original_dampeningFactor = toobusy.dampeningFactor();
+    toobusy.dampeningFactor(1); // for immediate reset
+
+    var resetID = setInterval(waitForNotBusy, 50);
+    function waitForNotBusy() {
+      if (toobusy()) return;
+      clearInterval(resetID);
+      toobusy.dampeningFactor(original_dampeningFactor);
+      done();
+    }
+  });
+
+  it('No dampening gets toobusy immediately', function(done) {
+    var cycles_to_toobusy = 0;
+    toobusy.dampeningFactor(1); // no dampening
+
+    function load(check) {
+      if (toobusy()) {
+        return check();
+      }
+      cycles_to_toobusy++;
+      var start = new Date();
+      while ((new Date() - start) < 250) {
+          tightWork();
+      }
+      setTimeout(load, 0, check);
+    }
+
+    load(function(){
+      (cycles_to_toobusy).should.equal(2);
+      done();
+    });
+  });
+
+  it('No dampening gets toobusy immediately', function(done) {
+    var cycles_to_toobusy = 0;
+    toobusy.dampeningFactor(25);
+
+    function load(check) {
+      if (toobusy()) {
+        return check();
+      }
+      cycles_to_toobusy++;
+      var start = new Date();
+      while ((new Date() - start) < 250) {
+          tightWork();
+      }
+      setTimeout(load, 0, check);
+    }
+
+    load(function(){
+      (cycles_to_toobusy).should.be.above(2);
+      done();
+    });
+  });
+});

--- a/tests.js
+++ b/tests.js
@@ -62,6 +62,18 @@ describe('toobusy()', function() {
 });
 
 describe('dampeningFactor', function() {
+  beforeEach(function resetToNotBusy(done) {
+    var original_dampeningFactor = toobusy.dampeningFactor();
+    toobusy.dampeningFactor(1); // for immediate reset
+
+    var resetID = setInterval(waitForNotBusy, 50);
+    function waitForNotBusy() {
+      if (toobusy()) return;
+      clearInterval(resetID);
+      toobusy.dampeningFactor(original_dampeningFactor);
+      done();
+    }
+  });
   it('should default to 3', function(done) {
     (toobusy.dampeningFactor()).should.equal(3);
     done();
@@ -76,23 +88,7 @@ describe('dampeningFactor', function() {
     (toobusy.dampeningFactor()).should.equal(5);
     done();
   });
-});
-
-describe('dampeningFactor\'s behaviour', function() {
-  beforeEach(function resetToNotBusy(done) {
-    var original_dampeningFactor = toobusy.dampeningFactor();
-    toobusy.dampeningFactor(1); // for immediate reset
-
-    var resetID = setInterval(waitForNotBusy, 50);
-    function waitForNotBusy() {
-      if (toobusy()) return;
-      clearInterval(resetID);
-      toobusy.dampeningFactor(original_dampeningFactor);
-      done();
-    }
-  });
-
-  it('No dampening gets toobusy immediately', function(done) {
+  it('should allow no dampening', function(done) {
     var cycles_to_toobusy = 0;
     toobusy.dampeningFactor(1); // no dampening
 
@@ -113,8 +109,7 @@ describe('dampeningFactor\'s behaviour', function() {
       done();
     });
   });
-
-  it('No dampening gets toobusy immediately', function(done) {
+  it('should respect larger dampening factors', function(done) {
     var cycles_to_toobusy = 0;
     toobusy.dampeningFactor(25);
 

--- a/toobusy.cc
+++ b/toobusy.cc
@@ -29,9 +29,8 @@ Handle<Value> TooBusy(const Arguments& args) {
     if (s_currentLag > HIGH_WATER_MARK_MS) {
         // probabilistically block requests proportional to how
         // far behind we are.
-        double pctToBlock = ((s_currentLag - HIGH_WATER_MARK_MS) /
-                             (double) HIGH_WATER_MARK_MS) * 100.0;
-        double r = (rand() / (double) RAND_MAX) * 100.0;
+        double pctToBlock = (s_currentLag - HIGH_WATER_MARK_MS) / (double) HIGH_WATER_MARK_MS;
+        double r = rand() / (double) RAND_MAX;
         if (r < pctToBlock) block = true;
     }
     return block ? True() : False();


### PR DESCRIPTION
The hardcoded 2:1 ratio for the dampening factor might not smooth spikes enough for all apps, this PR makes the dampening factor a tunable. It is backward compatible.

Although not related I've added a commit to remove the unnecessary `* 100.0` operations as well.

I tried to follow the style. Feedback much appreciated.
