### PR TITLE
fix(load) put response stream into flowing mode

### DIFF
--- a/examples/load.js
+++ b/examples/load.js
@@ -48,6 +48,8 @@ setInterval(function() {
         running--;
         cEndOrError();
       });
+      
+      res.resume();
     }).on('error', function(e) {
       process.stderr.write(e.toString() + " - " + (new Date() - start) + "ms\n");
       avg = ((new Date() - start) + avg * started) / (started + 1);


### PR DESCRIPTION
As we don't interested in actual data we need to put response stream into flowing mode, so `end` event could be emitted. 

P.S. interesting example :)
